### PR TITLE
[SLING-12493] Progressive cleanup of test cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>41</version>
+        <version>48</version>
         <relativePath />
     </parent>
 
@@ -104,7 +104,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
-            <version>2.1.0</version>
+            <version>2.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -145,13 +145,13 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.resource</artifactId>
-            <version>2.3.8</version>
+            <version>3.3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.testing</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -162,32 +162,32 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.osgi-mock</artifactId>
-            <version>2.3.4</version>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-api</artifactId>
-            <version>2.19.2</version>
-            <scope>test</scope>
+                <artifactId>oak-jackrabbit-api</artifactId>
+                <version>1.72.0</version>
+                <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>2.19.4</version>
+            <version>2.19.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-core</artifactId>
-            <version>2.19.4</version>
+            <version>2.19.6 </version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/apache/sling/scripting/javascript/internal/ScriptEngineHelper.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/internal/ScriptEngineHelper.java
@@ -33,7 +33,9 @@ import javax.script.SimpleScriptContext;
 import org.apache.sling.commons.testing.osgi.MockBundle;
 import org.apache.sling.commons.testing.osgi.MockComponentContext;
 import org.apache.sling.scripting.api.ScriptCache;
-import org.mockito.internal.util.reflection.Whitebox;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Wrapper;
@@ -43,19 +45,30 @@ import static org.mockito.Mockito.mock;
 
 /** Helpers to run javascript code fragments in tests */
 public class ScriptEngineHelper {
+
     private static ScriptEngine engine;
-    private static ScriptCache scriptCache = mock(ScriptCache.class);
+
+    @Mock
+    private static ScriptCache scriptCache;
+
+    @Mock
+    private static RhinoJavaScriptEngineFactoryConfiguration configuration;
+
+    @InjectMocks
+    private RhinoJavaScriptEngineFactory factory;
+
+    public ScriptEngineHelper() {
+        MockitoAnnotations.initMocks(this);
+    }
 
     public static class Data extends HashMap<String, Object> {
     }
 
-    private static ScriptEngine getEngine() {
+    private ScriptEngine getEngine() {
         if (engine == null) {
             synchronized (ScriptEngineHelper.class) {
                 final RhinoMockComponentContext componentContext = new RhinoMockComponentContext();
                 final RhinoJavaScriptEngineFactoryConfiguration configuration = mock(RhinoJavaScriptEngineFactoryConfiguration.class);
-                RhinoJavaScriptEngineFactory factory = new RhinoJavaScriptEngineFactory();
-                Whitebox.setInternalState(factory, "scriptCache", scriptCache);
                 factory.activate(componentContext, configuration);
                 engine = factory.getScriptEngine();
             }

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
@@ -44,7 +44,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.commons.testing.sling.MockResourceResolver;
-import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
 import org.jetbrains.annotations.NotNull;


### PR DESCRIPTION
* Updated sling-bundle-parent to version 48.
* Upgraded test dependencies to the latest compatible versions.
* Migrated unit tests to use Mockito 5.