### PR TITLE
SLING-12510 - Migrate JavaScript Support Test Cases to JUnit 5 for Sl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,18 @@
         </plugins>
     </reporting>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.11.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.osgi</groupId>
@@ -143,6 +155,11 @@
         </dependency>
         <!-- Testing -->
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.resource</artifactId>
             <version>3.3.2</version>
@@ -162,7 +179,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+            <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
+            <version>3.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
             <version>3.5.0</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/org/apache/sling/scripting/javascript/RepositoryScriptingTestBase.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/RepositoryScriptingTestBase.java
@@ -24,6 +24,8 @@ import javax.naming.NamingException;
 
 import org.apache.sling.commons.testing.jcr.RepositoryTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 
 /** Base class for tests which need a Repository
@@ -33,11 +35,18 @@ public class RepositoryScriptingTestBase extends RepositoryTestBase {
     private int counter;
     
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         script = new ScriptEngineHelper();
     }
-    
+
+    @Override
+    @AfterEach
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
     protected Node getNewNode() throws RepositoryException, NamingException {
         return getTestRootNode().addNode("test-" + (++counter));
     }

--- a/src/test/java/org/apache/sling/scripting/javascript/TestSetupTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/TestSetupTest.java
@@ -19,22 +19,26 @@
 package org.apache.sling.scripting.javascript;
 
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.junit.jupiter.api.Test;
 
 
 /** Verify that our test environment works */
-public class TestSetupTest extends RepositoryScriptingTestBase {
+class TestSetupTest extends RepositoryScriptingTestBase {
     
     /** Test our test repository setup */
-    public void testRootNode() throws Exception {
+    @Test
+    void testRootNode() throws Exception {
         assertNotNull(getTestRootNode());
     }
     
     /** Test our script engine setup */
-    public void testScripting() throws Exception {
+    @Test
+    void testScripting() throws Exception {
         assertEquals("something",script.evalToString("out.print('something')"));
     }
     
-    public void testScriptingWithData() throws Exception {
+    @Test
+    void testScriptingWithData() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("a", "A");
         data.put("b", "B");

--- a/src/test/java/org/apache/sling/scripting/javascript/internal/RhinoJavaScriptEngineFactoryTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/internal/RhinoJavaScriptEngineFactoryTest.java
@@ -24,22 +24,23 @@ import javax.script.ScriptEngineFactory;
 
 import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
 import org.apache.sling.scripting.api.ScriptCache;
-import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
+import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RhinoJavaScriptEngineFactoryTest {
+@ExtendWith(OsgiContextExtension.class)
+class RhinoJavaScriptEngineFactoryTest {
 
-    @Rule
-    public OsgiContext context = new OsgiContext();
+    private final OsgiContext context = new OsgiContext();
 
     @Test
-    public void testRegistrationProperties() {
+    void testRegistrationProperties() {
         DynamicClassLoaderManager dynamicClassLoaderManager = mock(DynamicClassLoaderManager.class);
         when(dynamicClassLoaderManager.getDynamicClassLoader()).thenReturn(RhinoJavaScriptEngineFactoryTest.class.getClassLoader());
         context.registerService(DynamicClassLoaderManager.class, dynamicClassLoaderManager);
@@ -49,7 +50,7 @@ public class RhinoJavaScriptEngineFactoryTest {
         assertEquals(Arrays.asList("rhino", "Rhino", "javascript", "JavaScript", "ecmascript", "ECMAScript"), instance.getNames());
         assertEquals("ECMAScript", instance.getLanguageName());
         assertEquals("partial ECMAScript 2015 support", instance.getLanguageVersion());
-        assertTrue("Unexpected engine name", instance.getEngineName() != null && instance.getEngineName().contains("Rhino 1.7.7.1_1"));
+        assertTrue( instance.getEngineName() != null && instance.getEngineName().contains("Rhino 1.7.7.1_1"), "Unexpected engine name" );
     }
 
 }

--- a/src/test/java/org/apache/sling/scripting/javascript/internal/RhinoJavaScriptEngineTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/internal/RhinoJavaScriptEngineTest.java
@@ -31,13 +31,18 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ImporterTopLevel;
 import org.mozilla.javascript.Scriptable;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-public class RhinoJavaScriptEngineTest extends TestCase {
+class RhinoJavaScriptEngineTest {
 
     private static ScriptCache scriptCache = Mockito.mock(ScriptCache.class);
 
-    public void testPreserveScopeBetweenEvals() throws ScriptException {
+    @Test
+    void testPreserveScopeBetweenEvals() throws ScriptException {
         MockRhinoJavaScriptEngineFactory factory = new MockRhinoJavaScriptEngineFactory();
         ScriptEngine engine = factory.getScriptEngine();
         Bindings context = new SimpleBindings();
@@ -46,13 +51,14 @@ public class RhinoJavaScriptEngineTest extends TestCase {
         try {
             result = engine.eval("f += 1", context);
         } catch (ScriptException e) {
-            TestCase.fail(e.getMessage());
+            fail(e.getMessage());
         }
         assertTrue(result instanceof Double);
         assertEquals(2.0, result);
     }
 
-    public void testNullSuppliedValue() throws ScriptException {
+    @Test
+    void testNullSuppliedValue() throws ScriptException {
         MockRhinoJavaScriptEngineFactory factory = new MockRhinoJavaScriptEngineFactory();
         ScriptEngine engine = factory.getScriptEngine();
         Bindings context = new LazyBindings();
@@ -69,7 +75,8 @@ public class RhinoJavaScriptEngineTest extends TestCase {
         assertTrue(throwable.getMessage().contains("\"suppliedNullValue\" is not defined"));
     }
 
-    public void testNotNullSuppliedValue() throws ScriptException {
+    @Test
+    void testNotNullSuppliedValue() throws ScriptException {
         MockRhinoJavaScriptEngineFactory factory = new MockRhinoJavaScriptEngineFactory();
         ScriptEngine engine = factory.getScriptEngine();
         Bindings context = new LazyBindings();

--- a/src/test/java/org/apache/sling/scripting/javascript/internal/ScriptEngineHelper.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/internal/ScriptEngineHelper.java
@@ -52,13 +52,13 @@ public class ScriptEngineHelper {
     private static ScriptCache scriptCache;
 
     @Mock
-    private static RhinoJavaScriptEngineFactoryConfiguration configuration;
+    private RhinoJavaScriptEngineFactoryConfiguration factoryConfiguration;
 
     @InjectMocks
     private RhinoJavaScriptEngineFactory factory;
 
     public ScriptEngineHelper() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     public static class Data extends HashMap<String, Object> {
@@ -67,9 +67,7 @@ public class ScriptEngineHelper {
     private ScriptEngine getEngine() {
         if (engine == null) {
             synchronized (ScriptEngineHelper.class) {
-                final RhinoMockComponentContext componentContext = new RhinoMockComponentContext();
-                final RhinoJavaScriptEngineFactoryConfiguration configuration = mock(RhinoJavaScriptEngineFactoryConfiguration.class);
-                factory.activate(componentContext, configuration);
+                factory.activate( new RhinoMockComponentContext(), factoryConfiguration);
                 engine = factory.getScriptEngine();
             }
         }

--- a/src/test/java/org/apache/sling/scripting/javascript/internal/TestPathRegexp.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/internal/TestPathRegexp.java
@@ -18,11 +18,13 @@
  */
 package org.apache.sling.scripting.javascript.internal;
 
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+class TestPathRegexp {
 
-public class TestPathRegexp extends TestCase {
-	public void testParentPath() {
+	@Test
+	void testParentPath() {
 		String regexp = "([^/]*/)?[^/]*/\\.\\./";
 		assertEquals("math", "/../math".replaceAll(regexp, ""));
 		assertEquals("math", "increment/../math".replaceAll(regexp, ""));
@@ -30,7 +32,8 @@ public class TestPathRegexp extends TestCase {
 		assertEquals("foo/math", "foo/bar/increment/../math".replaceAll(regexp, ""));
 	}
 
-	public void testCurrentPath() {
+	@Test
+	void testCurrentPath() {
 		String regexp = "[^/]*/\\./";
 		assertEquals("math", "/./math".replaceAll(regexp, ""));
 		assertEquals("math", "increment/./math".replaceAll(regexp, ""));

--- a/src/test/java/org/apache/sling/scripting/javascript/io/EspReaderTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/io/EspReaderTest.java
@@ -21,80 +21,101 @@ package org.apache.sling.scripting.javascript.io;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.stream.Stream;
 
 import javax.script.ScriptException;
-
-import junit.framework.TestCase;
-
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The <code>EspReaderTest</code> contains some simple test cases for the
  * <code>EspReader</code> class which processes ESP (ECMA Server Page) templated
  * JavaScript and produces plain JavaScript.
  */
-public class EspReaderTest extends TestCase {
+class EspReaderTest {
 
     /** Test read() method */
-    public void testReadSingle() throws IOException {
+    @Test
+    void testReadSingle() throws IOException {
         String src = "<%var%>"; // expect var on reader
 
         Reader reader = new EspReader(new StringReader(src));
-
-        assertTrue("Character 1 must be 'v'", 'v' == reader.read());
-        assertTrue("Character 2 must be 'a'", 'a' == reader.read());
-        assertTrue("Character 3 must be 'r'", 'r' == reader.read());
-        assertTrue("Character 4 must be -1", -1 == reader.read());
+        try {
+            assertEquals('v', reader.read(), "Character 1 must be 'v'");
+            assertEquals('a', reader.read(), "Character 2 must be 'a'");
+            assertEquals('r', reader.read(), "Character 3 must be 'r'");
+            assertEquals(-1, reader.read(), "Character 4 must be -1");
+        } finally {
+            reader.close();
+        }
     }
 
     /** Test read(char[], int, int) method */
-    public void testReadArrayAll() throws IOException {
+    @Test
+    void testReadArrayAll() throws IOException {
         String src = "<%var%>"; // expect var on reader
 
         Reader reader = new EspReader(new StringReader(src));
-        char[] buf = new char[3];
-        int rd = reader.read(buf, 0, buf.length);
+        try {
+            char[] buf = new char[3];
+            int rd = reader.read(buf, 0, buf.length);
 
-        assertEquals(3, rd);
-        assertEquals("var", new String(buf, 0, rd));
+            assertEquals(3, rd);
+            assertEquals("var", new String(buf, 0, rd));
 
-        // nothing more to read, expect EOF
-        rd = reader.read(buf, 0, buf.length);
-        assertEquals(-1, rd);
+            // nothing more to read, expect EOF
+            rd = reader.read(buf, 0, buf.length);
+            assertEquals(-1, rd);
+        } finally {
+            reader.close();
+        }
     }
 
     /** Test read(char[], int, int) method */
-    public void testReadArrayOffset() throws IOException {
+    @Test
+    void testReadArrayOffset() throws IOException {
         String jsSrc = "var x = 0;";
         String src = "<%" + jsSrc + "%>";
 
         Reader reader = new EspReader(new StringReader(src));
-        char[] buf = new char[10];
-        int off = 2;
-        int len = 3;
-        int rd = reader.read(buf, off, len);
-        assertEquals(len, rd);
-        assertEquals("var", new String(buf, off, rd));
+        try {
+            char[] buf = new char[10];
+            int off = 2;
+            int len = 3;
+            int rd = reader.read(buf, off, len);
+            assertEquals(len, rd);
+            assertEquals("var", new String(buf, off, rd));
 
-        off = 2;
-        len = 7;
-        rd = reader.read(buf, off, len);
-        assertEquals(len, rd);
-        assertEquals(" x = 0;", new String(buf, off, rd));
+            off = 2;
+            len = 7;
+            rd = reader.read(buf, off, len);
+            assertEquals(len, rd);
+            assertEquals(" x = 0;", new String(buf, off, rd));
 
-        // nothing more to read, expect EOF
-        rd = reader.read(buf, 0, buf.length);
-        assertEquals(-1, rd);
+            // nothing more to read, expect EOF
+            rd = reader.read(buf, 0, buf.length);
+            assertEquals(-1, rd);
+        } finally {
+            reader.close();
+        }
     }
 
     /** Test standard template text */
-    public void testTemplate() throws IOException {
+    @Test
+    void testTemplate() throws IOException {
         assertEquals("out=response.writer;out.write(\"test\");", parse("test"));
         assertEquals("out=response.writer;out.write(\"test\\n\");\nout.write(\"test2\");", parse("test\ntest2"));
     }
     
     /** Test with a custom "out" initialization */
-    public void testOutInit() throws IOException {
+    @Test
+    void testOutInit() throws IOException {
         final String input = "test";
         final String expected = "out=getOut();out.write(\"test\");";
             
@@ -111,52 +132,64 @@ public class EspReaderTest extends TestCase {
     }
 
     /** Test plain JavaScript code */
-    public void testCode() throws IOException {
+    @Test
+    void testCode() throws IOException {
         assertEquals(" test(); ", parse("<% test(); %>"));
         assertEquals(" \ntest();\ntest2(); ", parse("<% \ntest();\ntest2(); %>"));
     }
 
     /** Test JavaScript expressions */
-    public void testExpr() throws IOException {
+    @Test
+    void testExpr() throws IOException {
         assertEquals("out=response.writer;out.write( x + 1 );", parse("<%= x + 1 %>"));
         assertEquals("out=response.writer;out.write(\"<!-- \");out.write( x + 1 );out.write(\" -->\");", parse("<!-- <%= x + 1 %> -->"));
     }
 
     /** Test JavaScript comment */
-    public void testComment() throws IOException {
+    @Test
+    void testComment() throws IOException {
         assertEquals("", parse("<%-- test(); --%>"));
     }
-    
-    public void testCompactExpressionsDouble() throws IOException {
-    	final String input = "<html version=\"${1+1}\">\n";
-    	final String expected = "out=response.writer;out.write(\"<html version=\\\"\");out.write(1+1);out.write(\"\\\">\\n\");\n";
+
+    @ParameterizedTest
+    @MethodSource("CompactExpressionCases")
+    void testCompactExpressions(final String input, final String expected) throws IOException {
     	final String actual = parse(input);
         assertEquals(flatten(expected), flatten(actual));
     }
-    
-    public void testCompactExpressionsDoubleNegative() throws IOException {
-    	final String input = "<html version=\"{1+1}\">\n";
-    	final String expected = "out=response.writer;out.write(\"<html version=\\\"{1+1}\\\">\\n\");\n";
-    	final String actual = parse(input);
-        assertEquals(flatten(expected), flatten(actual));
+
+    static Stream<Arguments> CompactExpressionCases() {
+        return Stream.of( 
+            Arguments.of(
+                // input 
+                Named.of("testCompactExpressionsDouble", "<html version=\"${1+1}\">\n"),
+                // expected
+                "out=response.writer;out.write(\"<html version=\\\"\");out.write(1+1);out.write(\"\\\">\\n\");\n"
+            ),
+            Arguments.of(
+                // input
+                Named.of("testCompactExpressionsDoubleNegative", "<html version=\"{1+1}\">\n"),
+                // expected
+                "out=response.writer;out.write(\"<html version=\\\"{1+1}\\\">\\n\");\n"
+            ),
+            Arguments.of(
+                // input
+                Named.of("testCompactExpressionsSingle", "<html version='${1+1}'>\n"),
+                // expected
+                "out=response.writer;out.write(\"<html version='\");out.write(1+1);out.write(\"'>\\n\");\n"
+            ),
+            Arguments.of(
+                // input
+                Named.of("testCompactExpressionsSingleNegative", "<html version='{1+1}'>\n"),
+                // expected
+                "out=response.writer;out.write(\"<html version='{1+1}'>\\n\");\n"
+            )
+        );
     }
-    
-    public void testCompactExpressionsSingle() throws IOException {
-    	final String input = "<html version='${1+1}'>\n";
-    	final String expected = "out=response.writer;out.write(\"<html version='\");out.write(1+1);out.write(\"'>\\n\");\n";
-    	final String actual = parse(input);
-        assertEquals(flatten(expected), flatten(actual));
-    }
-    
-    public void testCompactExpressionsSingleNegative() throws IOException {
-    	final String input = "<html version='{1+1}'>\n";
-    	final String expected = "out=response.writer;out.write(\"<html version='{1+1}'>\\n\");\n";
-    	final String actual = parse(input);
-        assertEquals(flatten(expected), flatten(actual));
-    }
-    
+
     /** Test a complete template, using all features */
-    public void testCompleteTemplate() throws IOException {
+    @Test
+    void testCompleteTemplate() throws IOException {
         final String input =
             "<html>\n"
             + "<head><title><%= someExpr %></title></head>\n"
@@ -197,7 +230,8 @@ public class EspReaderTest extends TestCase {
     }
 
     /** Test a complete template, using all features */
-    public void testNumericExpression() throws IOException {
+    @Test
+    void testNumericExpression() throws IOException {
         String input = "<%= 1 %>";
         String expected = "out=response.writer;out.write( 1 );";
         String actual = parse(input);
@@ -215,7 +249,8 @@ public class EspReaderTest extends TestCase {
     }
     
     /** Test a complete template, using all features */
-    public void testNumericExpressionOutput() throws ScriptException {
+    @Test
+    void testNumericExpressionOutput() throws ScriptException {
         ScriptEngineHelper script = new ScriptEngineHelper();
         
         String input = "out.write( 1 );";
@@ -234,7 +269,8 @@ public class EspReaderTest extends TestCase {
         assertEquals(expected, actual);
     }
     
-    public void testColon() throws IOException {
+    @Test
+    void testColon() throws IOException {
         final String input = "currentNode.text:<%= currentNode.text %>";
         final String expected = 
             "out=response.writer;" 
@@ -245,7 +281,8 @@ public class EspReaderTest extends TestCase {
         assertEquals(expected, actual);
     }
     
-    public void testEqualSigns() throws IOException {
+    @Test
+    void testEqualSigns() throws IOException {
         final String input = "currentNode.text=<%= currentNode.text %>";
         final String expected = 
             "out=response.writer;" 
@@ -256,7 +293,8 @@ public class EspReaderTest extends TestCase {
         assertEquals(expected, actual);
     }
     
-    public void testSingleQuoted() throws IOException {
+    @Test
+    void testSingleQuoted() throws IOException {
         final String input = "currentNode.text='<%= currentNode.text %>'";
         final String expected = 
             "out=response.writer;" 
@@ -268,7 +306,8 @@ public class EspReaderTest extends TestCase {
         assertEquals(expected, actual);
     }
     
-    public void testDoubleQuoted() throws IOException {
+    @Test
+    void testDoubleQuoted() throws IOException {
         final String input = "currentNode.text=\"<%= currentNode.text %>\"";
         final String expected = 
             "out=response.writer;" 
@@ -285,12 +324,16 @@ public class EspReaderTest extends TestCase {
         StringBuffer buf = new StringBuffer();
 
         Reader r = new EspReader(new StringReader(text));
-        int c;
-        while ( (c=r.read()) >= 0) {
-            buf.append( (char) c);
-        }
+        try {
+            int c;
+            while ( (c=r.read()) >= 0) {
+                buf.append( (char) c);
+            }
 
-        return buf.toString();
+            return buf.toString();
+        } finally {
+            r.close();
+        } 
     }
     
     /** Replace \n with . in strings to make it easier to compare visually for testing */

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableMapTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableMapTest.java
@@ -23,15 +23,18 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ScriptableMapTest extends RepositoryScriptingTestBase {
+
+class ScriptableMapTest extends RepositoryScriptingTestBase {
 
     private ValueMap valueMap;
     private ScriptEngineHelper.Data data;
 
-    @Before
+    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         valueMap = new ValueMapDecorator(new HashMap<String, Object>() {{
@@ -42,14 +45,15 @@ public class ScriptableMapTest extends RepositoryScriptingTestBase {
         data.put("properties", valueMap);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         valueMap.clear();
         data.clear();
         super.tearDown();
     }
 
-    public void testPropertyAccess() throws ScriptException {
+    @Test
+    void testPropertyAccess() throws ScriptException {
         assertEquals("a", script.eval("properties['a']", data));
         assertEquals("a", script.eval("properties.a", data));
         assertEquals(1, script.eval("properties['b']", data));
@@ -57,7 +61,8 @@ public class ScriptableMapTest extends RepositoryScriptingTestBase {
         assertEquals(null, script.eval("properties['c']", data));
     }
 
-    public void testJavaMethods() throws ScriptException {
+    @Test
+    void testJavaMethods() throws ScriptException {
         assertEquals(2, script.eval("properties.size()", data));
     }
 }

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableNodeTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableNodeTest.java
@@ -27,12 +27,15 @@ import javax.jcr.Value;
 
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 
 /** Test the ScriptableNode class "live", by retrieving
  *  Nodes from a Repository and executing javascript code
  *  using them.
  */
-public class ScriptableNodeTest extends RepositoryScriptingTestBase {
+class ScriptableNodeTest extends RepositoryScriptingTestBase {
 
     private Node node;
     private Property textProperty;
@@ -44,6 +47,7 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
     private ScriptEngineHelper.Data data;
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -68,7 +72,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         data.put("calProperty", calProperty);
     }
 
-    public void testDefaultValue() throws Exception {
+    @Test
+    void testDefaultValue() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("node", getTestRootNode());
         assertEquals(
@@ -77,7 +82,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testPrimaryNodeType() throws Exception {
+    @Test
+    void testPrimaryNodeType() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("node", getTestRootNode());
         assertEquals(
@@ -86,7 +92,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testPrimaryNodeTypeProperty() throws Exception {
+    @Test
+    void testPrimaryNodeTypeProperty() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("node", getTestRootNode());
         assertEquals(
@@ -95,56 +102,64 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testViaPropertyNoWrappers() throws Exception {
+    @Test
+    void testViaPropertyNoWrappers() throws Exception {
         assertEquals(
             testText,
             script.evalToString("out.print(property.value.string)", data)
         );
     }
 
-    public void testViaPropertyWithWrappers() throws Exception {
+    @Test
+    void testViaPropertyWithWrappers() throws Exception {
         assertEquals(
             textProperty.getString(),
             script.evalToString("out.print(property)", data)
         );
     }
 
-    public void testViaNodeDirectPropertyAccess() throws Exception {
+    @Test
+    void testViaNodeDirectPropertyAccess() throws Exception {
         assertEquals(
             testText,
             script.evalToString("out.print(node.text)", data)
         );
     }
 
-    public void testViaPropertyNoWrappersNum() throws Exception {
+    @Test
+    void testViaPropertyNoWrappersNum() throws Exception {
         assertEquals(
             testNum,
             script.eval("numProperty.value.getDouble()", data)
         );
     }
 
-    public void testViaPropertyWithWrappersNum() throws Exception {
+    @Test
+    void testViaPropertyWithWrappersNum() throws Exception {
         assertEquals(
             testNum,
             script.eval("0+numProperty", data)
         );
     }
 
-    public void testViaNodeDirectPropertyAccessNum() throws Exception {
+    @Test
+    void testViaNodeDirectPropertyAccessNum() throws Exception {
         assertEquals(
             testNum,
             script.eval("node.num", data)
         );
     }
 
-    public void testViaPropertyNoWrappersCal() throws Exception {
+    @Test
+    void testViaPropertyNoWrappersCal() throws Exception {
         assertEquals(
                 testCal.getTimeInMillis(),
                 script.eval("calProperty.value.getDate().getTimeInMillis()", data)
         );
     }
 
-    public void testViaNodeDirectPropertyAccessCal() throws Exception {
+    @Test
+    void testViaNodeDirectPropertyAccessCal() throws Exception {
     	final SimpleDateFormat f = new SimpleDateFormat(ScriptableCalendar.ECMA_DATE_FORMAT, ScriptableCalendar.DATE_FORMAT_LOCALE);
     	final String expected = f.format(testCal.getTime());
         assertEquals(
@@ -153,14 +168,16 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testCalDateClass() throws Exception {
+    @Test
+    void testCalDateClass() throws Exception {
         assertEquals(
                 "number",
                 script.evalToString("out.print(typeof node.cal.date.time)", data)
         );
     }
 
-    public void testPropertyParent() throws Exception {
+    @Test
+    void testPropertyParent() throws Exception {
         // need to use node.getProperty('num') to have a ScriptableProperty,
         // node.num only returns a wrapped value
         assertEquals(
@@ -169,7 +186,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testPropertyAncestor() throws Exception {
+    @Test
+    void testPropertyAncestor() throws Exception {
         // call getAncestor which is not explicitly defined in ScriptableProperty,
         // to verify that all Property methods are available and that we get a
         // correctly wrapped result (SLING-397)
@@ -179,7 +197,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         );
     }
 
-    public void testPropertiesIterationNoWrapper() throws Exception {
+    @Test
+    void testPropertiesIterationNoWrapper() throws Exception {
         final String code =
             "var props = node.getProperties();"
             + " for(i in props) { out.print(props[i].name); out.print(' '); }"
@@ -191,7 +210,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         }
     }
 
-    public void testAddNodeDefaultType() throws Exception {
+    @Test
+    void testAddNodeDefaultType() throws Exception {
         final String path = "subdt_" + System.currentTimeMillis();
         final String code =
             "var n = node.addNode('" + path + "');\n"
@@ -200,7 +220,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals("nt:unstructured", script.evalToString(code, data));
     }
 
-    public void testAddNodeSpecificType() throws Exception {
+    @Test
+    void testAddNodeSpecificType() throws Exception {
         final String path = "subst_" + System.currentTimeMillis();
         final String code =
             "var n = node.addNode('" + path + "', 'nt:folder');\n"
@@ -209,7 +230,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals("nt:folder", script.evalToString(code, data));
     }
 
-    public void testGetNode() throws Exception {
+    @Test
+    void testGetNode() throws Exception {
         final String path = "subgn_" + System.currentTimeMillis();
         final String code =
             "node.addNode('" + path + "', 'nt:resource');\n"
@@ -219,12 +241,14 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals("nt:resource", script.evalToString(code, data));
     }
 
-    public void testGetProperty() throws Exception {
+    @Test
+    void testGetProperty() throws Exception {
         final String code = "out.print(node.getProperty('text'));";
         assertEquals(testText, script.evalToString(code, data));
     }
 
-    public void testGetNodesNoPattern() throws Exception {
+    @Test
+    void testGetNodesNoPattern() throws Exception {
         final String path = "subgnnp_" + System.currentTimeMillis();
         final String code =
             "node.addNode('" + path + "_A');\n"
@@ -235,7 +259,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals(path + "_A " + path + "_B ", script.evalToString(code, data));
     }
 
-    public void testGetNodesWithPattern() throws Exception {
+    @Test
+    void testGetNodesWithPattern() throws Exception {
         final String path = "subgnnp_" + System.currentTimeMillis();
         final String code =
             "node.addNode('1_" + path + "_A');\n"
@@ -247,7 +272,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals("1_" + path + "_A 1_" + path + "_B ", script.evalToString(code, data));
     }
 
-    public void testRemoveNode() throws Exception {
+    @Test
+    void testRemoveNode() throws Exception {
         final String code =
             "node.addNode('toremove');\n"
             + "out.print(node.hasNode('toremove'))\n"
@@ -259,12 +285,14 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
     }
 
     /** Test SLING-389 */
-    public void testForCurrentNode() throws Exception {
+    @Test
+    void testForCurrentNode() throws Exception {
         final String code = "for (var a in node) {}; out.print('ok')";
         assertEquals("ok", script.evalToString(code, data));
     }
 
-    public void testChildNodeAccess() throws Exception {
+    @Test
+    void testChildNodeAccess() throws Exception {
         final String path = "subtcna_" + System.currentTimeMillis();
         final String code =
             "node.addNode('" + path + "');\n"
@@ -280,7 +308,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
     /** Verify that the getAncestor() method (which is not explicitely defined in ScriptableNode)
      *  is available, to check SLING-397.
      */
-    public void testGetAncestor() throws Exception {
+    @Test
+    void testGetAncestor() throws Exception {
         {
             final String code = "out.print(node.getAncestor(0).getPath());";
             assertEquals("/", script.evalToString(code, data));
@@ -292,7 +321,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         }
     }
 
-    public void testIsNodeType() throws Exception {
+    @Test
+    void testIsNodeType() throws Exception {
         final String code =
             "out.print(node.isNodeType('nt:unstructured'));\n"
             + "out.print(' ');\n"
@@ -301,7 +331,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
         assertEquals("true false", script.evalToString(code, data));
     }
 
-    public void testGetSession() throws Exception {
+    @Test
+    void testGetSession() throws Exception {
         assertEquals(
                 "Root node found via node.session",
                 "/",
@@ -318,7 +349,8 @@ public class ScriptableNodeTest extends RepositoryScriptingTestBase {
      * Test for regressing this issue:
      * https://issues.apache.org/jira/browse/SLING-534
      */
-    public void testMultiValReferencePropLookup() throws Exception {
+    @Test
+    void testMultiValReferencePropLookup() throws Exception {
         Node refNode1 = getNewNode();
         refNode1.addMixin("mix:referenceable");
         Node refNode2 = getNewNode();

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
@@ -43,20 +43,29 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
-import org.apache.sling.commons.testing.sling.MockResourceResolver;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Wrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ScriptableResourceTest extends RepositoryScriptingTestBase {
+
+@ExtendWith(SlingContextExtension.class)
+class ScriptableResourceTest extends RepositoryScriptingTestBase {
+
+    private static final SlingContext context = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
 
     private Node node;
 
-    private static final ResourceResolver RESOURCE_RESOLVER = new MockResourceResolver();
+    private static final ResourceResolver RESOURCE_RESOLVER = context.resourceResolver();
 
     private static final String RESOURCE_TYPE = "testWrappedResourceType";
 
@@ -65,6 +74,7 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
     private static final Logger LOGGER = LoggerFactory.getLogger(ScriptableResourceTest.class);
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -79,7 +89,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         }
     }
 
-    public void testDefaultValuePath() throws Exception {
+    @Test
+    void testDefaultValuePath() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
 
@@ -90,7 +101,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(node.getPath(), script.eval("resource.getPath()", data));
     }
 
-    public void testResourceType() throws Exception {
+    @Test
+    void testResourceType() throws Exception {
         // set resource and resource super type
         node.setProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY,
             RESOURCE_TYPE);
@@ -108,7 +120,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
             data));
     }
 
-    public void testChildren() throws Exception {
+    @Test
+    void testChildren() throws Exception {
         node.addNode("first-child");
         node.addNode("second-child");
 
@@ -119,7 +132,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals("first-child", script.eval("resource.getChildren()[0].name", data));
     }
 
-    public void testListChildren() throws Exception {
+    @Test
+    void testListChildren() throws Exception {
         Node firstChild = node.addNode("first-child");
         node.addNode("second-child");
 
@@ -130,7 +144,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(firstChild.getPath(), script.eval("resource.listChildren()[0].path", data));
     }
 
-    public void testGetChild() throws Exception {
+    @Test
+    void testGetChild() throws Exception {
         Node child = node.addNode("child");
 
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
@@ -139,7 +154,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(child.getPath(), script.eval("resource.getChild('./child').path", data));
     }
 
-    public void testGetParent() throws Exception {
+    @Test
+    void testGetParent() throws Exception {
         Node child = node.addNode("child");
         Node grandChild = child.addNode("grandchild");
 
@@ -149,7 +165,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(child.getPath(), script.eval("resource.getParent().getPath()", data));
     }
 
-    public void testParent() throws Exception {
+    @Test
+    void testParent() throws Exception {
         Node child = node.addNode("child");
         Node grandChild = child.addNode("grandchild");
 
@@ -159,13 +176,15 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(child.getPath(), script.eval("resource.parent.path", data));
     }
 
-    public void testIsResourceType() throws Exception {
+    @Test
+    void testIsResourceType() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
         assertEquals(Boolean.TRUE, script.eval("resource.isResourceType('" + RESOURCE_TYPE + "')", data));
     }
 
-    public void testResourceSuperType() throws Exception {
+    @Test
+    void testResourceSuperType() throws Exception {
         // set resource and resource super type
         node.setProperty(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY,
             RESOURCE_TYPE);
@@ -183,7 +202,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
             "resource.getResourceSuperType()", data));
     }
 
-    public void testResourceMetadata() throws Exception {
+    @Test
+    void testResourceMetadata() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
 
@@ -197,7 +217,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertResourceMetaData(script.eval("resource.getMetadata()", data));
     }
 
-    public void testResourceResolver() throws Exception {
+    @Test
+    void testResourceResolver() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
 
@@ -208,7 +229,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
             "resource.getResourceResolver()", data));
     }
 
-    public void testAdaptToNode() throws Exception {
+    @Test
+    void testAdaptToNode() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
 
@@ -219,7 +241,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
             "resource.adaptTo(Packages.javax.jcr.Node)", data));
     }
 
-    public void testAdaptToNothing() throws Exception {
+    @Test
+    void testAdaptToNothing() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         data.put("resource", new TestResource(node));
 
@@ -230,7 +253,8 @@ public class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals(true, script.eval("resource.adaptTo(Packages.java.util.Date) == undefined", data));
     }
 
-    public void testProperties() throws Exception {
+    @Test
+    void testProperties() throws Exception {
         final ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
         Calendar date = new GregorianCalendar();
         node.setProperty(JcrConstants.JCR_LASTMODIFIED, date);

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableVersionTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableVersionTest.java
@@ -22,14 +22,17 @@ import javax.jcr.Node;
 
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Test access to Version and VersionHistory objects */
-public class ScriptableVersionTest extends RepositoryScriptingTestBase {
+class ScriptableVersionTest extends RepositoryScriptingTestBase {
 
     private Node node;
     private ScriptEngineHelper.Data data = new ScriptEngineHelper.Data();
 
     @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
 
@@ -42,22 +45,26 @@ public class ScriptableVersionTest extends RepositoryScriptingTestBase {
         getSession().save();
     }
 
-    public void testVersionHistoryAccess() throws Exception {
+    @Test
+    void testVersionHistoryAccess() throws Exception {
         Object result = script.eval("node.getVersionHistory().getAllVersions()", data);
         assertNotNull(result);
     }
 
-    public void testVersionHistoryIsWrapped() throws Exception {
+    @Test
+    void testVersionHistoryIsWrapped() throws Exception {
         assertEquals("nt:versionHistory", script.eval("node.versionHistory['jcr:primaryType']", data));
         assertEquals("nt:version", script.eval("node.versionHistory.rootVersion['jcr:primaryType']", data));
     }
 
-    public void testVersionAccess() throws Exception {
+    @Test
+    void testVersionAccess() throws Exception {
         Object result = script.eval("node.getBaseVersion().getCreated()", data);
         assertNotNull(result);
     }
 
-    public void testVersionIsWrapped() throws Exception {
+    @Test
+    void testVersionIsWrapped() throws Exception {
         assertEquals("nt:version", script.eval("node.baseVersion['jcr:primaryType']", data));
         assertNotNull(script.eval("node.baseVersion.created", data));
     }


### PR DESCRIPTION
…ing Mocks Compatibility

* Migrated test cases to JUnit 5 with associated code clean-ups.
* Ensured proper closure of JCR sessions and EspReader after each test case.
* Removed usage of the deprecated initMocks() method.
* Resolved variable shadowing in object field declarations.
* Replaced four cut-and-paste ExpReader test cases with a single parameterized test.
* Eliminated usage of the deprecated MockResourceResolver.