### PR TITLE
SLING-12510 - Remove Double-Checked Locking in ScriptableBase.java

### DIFF
--- a/src/main/java/org/apache/sling/scripting/javascript/wrapper/ScriptableBase.java
+++ b/src/main/java/org/apache/sling/scripting/javascript/wrapper/ScriptableBase.java
@@ -34,7 +34,7 @@ public abstract class ScriptableBase extends ScriptableObject {
 
     public static final String JSFUNC_PREFIX = "jsFunction_";
 
-    protected Object getNative(String name, Scriptable start) {
+    protected synchronized Object getNative(String name, Scriptable start) {
         final Object wrapped = getWrappedObject();
 
         if(wrapped == null) {
@@ -46,11 +46,7 @@ public abstract class ScriptableBase extends ScriptableObject {
         }
 
         if(njo == null) {
-            synchronized (this) {
-                if(njo == null) {
-                    njo = new NativeJavaObject(start, wrapped, getStaticType());
-                }
-            }
+            njo = new NativeJavaObject(start, wrapped, getStaticType());
         }
 
         return njo.get(name, start);


### PR DESCRIPTION
* Eliminated the use of double-checked locking in wrapper/ScriptableBase.java to improve code safety and readability.