### PR TITLE
SLING-12492 bump org.apache.sling.api to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.21.0</version>
+            <version>2.25.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
updating the version to be the oldest compatible version that does not have known security vulnerabilities