### PR TITLE
SLING-13252: Migrate repository tests from commons.testing/Jackrabbit to sling-mock (Oak)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,18 +162,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.commons.testing</artifactId>
-            <version>2.1.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.jackrabbit</groupId>
-                    <artifactId>jackrabbit-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.osgi-mock.junit5</artifactId>
             <version>3.5.0</version>
             <scope>test</scope>
@@ -182,6 +170,19 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
             <version>3.5.0</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Oak 1.22 (Java 8 only) is replaced by the Java 17 compatible Oak from sling-mock-oak below. -->
+                <exclusion>
+                    <groupId>org.apache.jackrabbit</groupId>
+                    <artifactId>oak-jcr</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
+            <version>4.1.0-1.86.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -199,12 +200,6 @@
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
-            <version>2.19.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-core</artifactId>
             <version>2.19.6</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/org/apache/sling/scripting/javascript/RepositoryScriptingTestBase.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/RepositoryScriptingTestBase.java
@@ -20,15 +20,18 @@ package org.apache.sling.scripting.javascript;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.naming.NamingException;
+import javax.jcr.Session;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
-import org.apache.sling.commons.testing.jcr.RepositoryTestBase;
 import org.apache.sling.scripting.api.ScriptCache;
 import org.apache.sling.scripting.javascript.internal.RhinoJavaScriptEngineFactory;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
-import org.apache.sling.testing.mock.osgi.junit5.OsgiContext;
-import org.apache.sling.testing.mock.osgi.junit5.OsgiContextExtension;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,34 +39,60 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/** Base class for tests which need a Repository and scripting functionality */
-@ExtendWith(OsgiContextExtension.class)
-public class RepositoryScriptingTestBase extends RepositoryTestBase {
+/**
+ * Base class for tests which need a Repository and scripting functionality.
+ */
+@ExtendWith(SlingContextExtension.class)
+public class RepositoryScriptingTestBase {
 
-    private final OsgiContext osgiContext = new OsgiContext();
+    /** Unique suffix for the per-test root node; the Oak repository is shared across the JVM. */
+    private static final AtomicInteger rootCounter = new AtomicInteger();
+
+    protected final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
     protected ScriptEngineHelper script;
+    protected Session session;
+    private RhinoJavaScriptEngineFactory factory;
+    private Node testRootNode;
     private int counter;
 
-    @Override
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         DynamicClassLoaderManager dclm = mock(DynamicClassLoaderManager.class);
         when(dclm.getDynamicClassLoader()).thenReturn(getClass().getClassLoader());
-        osgiContext.registerService(DynamicClassLoaderManager.class, dclm);
-        osgiContext.registerService(ScriptCache.class, mock(ScriptCache.class));
-        RhinoJavaScriptEngineFactory factory = new RhinoJavaScriptEngineFactory();
-        osgiContext.registerInjectActivateService(factory);
+        context.registerService(DynamicClassLoaderManager.class, dclm);
+        context.registerService(ScriptCache.class, mock(ScriptCache.class));
+        factory = new RhinoJavaScriptEngineFactory();
+        context.registerInjectActivateService(factory);
         script = new ScriptEngineHelper(factory.getScriptEngine());
+        session = context.resourceResolver().adaptTo(Session.class);
     }
 
-    @Override
     @AfterEach
     protected void tearDown() throws Exception {
-        super.tearDown();
+        // Rhino's global ContextFactory keeps a set-once application class loader; deactivating the
+        // factory disposes it so the next activation in this JVM can set it again cleanly.
+        if (factory != null) {
+            MockOsgi.deactivate(factory, context.bundleContext());
+            factory = null;
+        }
+        if (session != null && session.isLive()) {
+            session.logout();
+        }
     }
 
-    protected Node getNewNode() throws RepositoryException, NamingException {
+    protected Session getSession() {
+        return session;
+    }
+
+    protected Node getTestRootNode() throws RepositoryException {
+        if (testRootNode == null) {
+            testRootNode = session.getRootNode().addNode("test_" + rootCounter.incrementAndGet(), "nt:unstructured");
+            session.save();
+        }
+        return testRootNode;
+    }
+
+    protected Node getNewNode() throws RepositoryException {
         return getTestRootNode().addNode("test-" + (++counter));
     }
 }

--- a/src/test/java/org/apache/sling/scripting/javascript/TestSetupTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/TestSetupTest.java
@@ -21,6 +21,9 @@ package org.apache.sling.scripting.javascript;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /** Verify that our test environment works */
 class TestSetupTest extends RepositoryScriptingTestBase {
 

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableMapTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableMapTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class ScriptableMapTest extends RepositoryScriptingTestBase {
 
     private ValueMap valueMap;

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableNodeTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableNodeTest.java
@@ -30,6 +30,9 @@ import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /** Test the ScriptableNode class "live", by retrieving
  *  Nodes from a Repository and executing javascript code
  *  using them.
@@ -162,7 +165,7 @@ class ScriptableNodeTest extends RepositoryScriptingTestBase {
         final String result = script.evalToString(code, data);
         final String[] names = {"text", "otherProperty"};
         for (String name : names) {
-            assertTrue("result (" + result + ") contains '" + name + "'", result.contains(name));
+            assertTrue(result.contains(name), "result (" + result + ") contains '" + name + "'");
         }
     }
 
@@ -273,11 +276,11 @@ class ScriptableNodeTest extends RepositoryScriptingTestBase {
     @Test
     void testGetSession() throws Exception {
         assertEquals(
-                "Root node found via node.session", "/", script.eval("node.session.getRootNode().getPath()", data));
+                "/", script.eval("node.session.getRootNode().getPath()", data), "Root node found via node.session");
         assertEquals(
-                "Root node found via node.getSession()",
                 "/",
-                script.eval("node.getSession().getRootNode().getPath()", data));
+                script.eval("node.getSession().getRootNode().getPath()", data),
+                "Root node found via node.getSession()");
     }
 
     /**

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableResourceTest.java
@@ -47,25 +47,21 @@ import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.scripting.javascript.RepositoryScriptingTestBase;
 import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.apache.sling.testing.mock.sling.junit5.SlingContext;
-import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mozilla.javascript.Wrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ExtendWith(SlingContextExtension.class)
-class ScriptableResourceTest extends RepositoryScriptingTestBase {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-    private static final SlingContext context = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+class ScriptableResourceTest extends RepositoryScriptingTestBase {
 
     private Node node;
 
-    private static final ResourceResolver RESOURCE_RESOLVER = context.resourceResolver();
+    private ResourceResolver resourceResolver;
 
     private static final String RESOURCE_TYPE = "testWrappedResourceType";
 
@@ -78,6 +74,7 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
     protected void setUp() throws Exception {
         super.setUp();
 
+        resourceResolver = context.resourceResolver();
         node = getNewNode();
 
         try {
@@ -213,8 +210,8 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
         data.put("resource", new TestResource(node));
 
         // official API
-        assertEquals(RESOURCE_RESOLVER, script.eval("resource.resourceResolver", data));
-        assertEquals(RESOURCE_RESOLVER, script.eval("resource.getResourceResolver()", data));
+        assertEquals(resourceResolver, script.eval("resource.resourceResolver", data));
+        assertEquals(resourceResolver, script.eval("resource.getResourceResolver()", data));
     }
 
     @Test
@@ -223,8 +220,8 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
         data.put("resource", new TestResource(node));
 
         // the node to which the resource adapts
-        assertEquals(node, script.eval("resource.adaptTo('javax.jcr.Node')", data));
-        assertEquals(node, script.eval("resource.adaptTo(Packages.javax.jcr.Node)", data));
+        assertNodeEquals(node, script.eval("resource.adaptTo('javax.jcr.Node')", data));
+        assertNodeEquals(node, script.eval("resource.adaptTo(Packages.javax.jcr.Node)", data));
     }
 
     @Test
@@ -253,12 +250,12 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
         assertEquals("testProperties", script.eval("resource.properties.test", data));
     }
 
-    private void assertEquals(Node expected, Object actual) {
+    private void assertNodeEquals(Node expected, Object actual) {
         while (actual instanceof Wrapper) {
             actual = ((Wrapper) actual).unwrap();
         }
 
-        super.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     private void assertResourceMetaData(Object metaData) throws Exception {
@@ -270,7 +267,7 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
         }
     }
 
-    private static class TestResource implements Resource {
+    private class TestResource implements Resource {
 
         private final Node node;
 
@@ -294,7 +291,7 @@ class ScriptableResourceTest extends RepositoryScriptingTestBase {
         }
 
         public ResourceResolver getResourceResolver() {
-            return RESOURCE_RESOLVER;
+            return resourceResolver;
         }
 
         @Override

--- a/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableVersionTest.java
+++ b/src/test/java/org/apache/sling/scripting/javascript/wrapper/ScriptableVersionTest.java
@@ -25,6 +25,9 @@ import org.apache.sling.scripting.javascript.internal.ScriptEngineHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /** Test access to Version and VersionHistory objects */
 class ScriptableVersionTest extends RepositoryScriptingTestBase {
 


### PR DESCRIPTION
## Summary

The repository-based tests (`RepositoryScriptingTestBase` and its subclasses `TestSetupTest`, `ScriptableMapTest`, `ScriptableNodeTest`, `ScriptableResourceTest`, `ScriptableVersionTest`) ran against the legacy `org.apache.sling.commons.testing` `RepositoryTestBase`, which starts a Jackrabbit 2 repository persisted via Apache Derby.

This had two problems:
- Derby rejects region-less JVM locales such as `en_001` (macOS "English — World") with `ERROR XBM0X`, failing every repository test on such machines (unfixed in Derby trunk).
- `RepositoryTestBase` is JUnit 3 (`TestCase`) based, conflicting with the JUnit 5 migration from SLING-12510.

## Changes

- Rebase `RepositoryScriptingTestBase` on sling-mock's `SlingContext` with `ResourceResolverType.JCR_OAK` (in-memory Oak), removing Derby from the test classpath.
- Drop the `commons.testing` and `jackrabbit-core` test dependencies; add `org.apache.sling.testing.sling-mock-oak` for a Java 17 compatible Oak and exclude the stale Oak 1.22 that `sling-mock.core` pulls transitively.
- Complete the JUnit 5 migration: remove all JUnit 3 `TestCase` inheritance and assertion usage.
- Deactivate the `RhinoJavaScriptEngineFactory` in `tearDown` so Rhino's set-once `ContextFactory` application class loader is reset between tests.

## Verification

`mvn clean verify` is green: 91 tests pass, no locale workaround required, RAT and bnd baseline checks pass.

JIRA: https://issues.apache.org/jira/browse/SLING-13252